### PR TITLE
Fix Bad Request errors in the Ruby Client

### DIFF
--- a/mockserver-client-ruby/lib/mockserver/abstract_client.rb
+++ b/mockserver-client-ruby/lib/mockserver/abstract_client.rb
@@ -26,7 +26,7 @@ module MockServer
     def initialize(host, port)
       fail 'Cannot instantiate AbstractClient class. You must subclass it.' if self.class == AbstractClient
       fail 'Host/port must not be nil' unless host && port
-      @base   = RestClient::Resource.new("http://#{host}:#{port}")
+      @base   = RestClient::Resource.new("http://#{host}:#{port}", headers: { 'Content-Type' => 'application/json' })
       @logger = ::LoggingFactory::DEFAULT_FACTORY.log(self.class)
     end
 

--- a/mockserver-client-ruby/spec/mockserver/mock_client_spec.rb
+++ b/mockserver-client-ruby/spec/mockserver/mock_client_spec.rb
@@ -12,10 +12,10 @@ describe MockServer::MockServerClient do
     client.logger = LoggingFactory::DEFAULT_FACTORY.log('test', output: 'tmp.log', truncate: true)
 
     # Stub requests
-    stub_request(:put, /.+\/expectation/).with(body: register_expectation_json).to_return(status: 201)
-    stub_request(:put, /.+\/clear/).with(body: search_request_json).to_return(status: 202)
-    stub_request(:put, /.+\/reset/).to_return(status: 202)
-    stub_request(:put, /.+\/retrieve/).with(body: search_request_json).to_return(body: '', status: 200)
+    stub_request(:put, /.+\/expectation/).with(body: register_expectation_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 201)
+    stub_request(:put, /.+\/clear/).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
+    stub_request(:put, /.+\/reset/).with(headers: { 'Content-Type' => 'application/json' }).to_return(status: 202)
+    stub_request(:put, /.+\/retrieve/).with(body: search_request_json, headers: { 'Content-Type' => 'application/json' }).to_return(body: '', status: 200)
   end
 
   it 'registers an expectation correctly' do


### PR DESCRIPTION
by adding a application/json Content-Type header
